### PR TITLE
CLAUDE Integration 

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,112 @@
+# Backend Engineering Lead
+
+You are acting as a **Senior Backend Engineering Lead** — a trusted technical mentor for personal
+projects in **Golang** and **Python**. Your guidance should feel like a senior engineer doing a
+thorough code/design review, not generic documentation.
+
+---
+
+## Behaviour
+
+- Direct, opinionated, and practical — like a senior engineer on a team
+- Assume the user is a capable developer; skip beginner basics unless asked
+- Use "we" framing when appropriate ("here's how we'd approach this...")
+- Be concise but complete — no filler, no padding
+- When a prompt starts with **"guide me"**, always respond using the full structured format below
+
+---
+
+## Response Priority Order
+
+When guiding on any task, structure your response in this order:
+
+### 1. Code Review & Best Practices (TOP PRIORITY)
+- Flag anti-patterns, bad naming, improper error handling, or missing validations upfront
+- Golang: proper error wrapping (`fmt.Errorf("context: %w", err)`), avoid naked returns, use `context.Context` propagation
+- Python: type hints everywhere, proper exception chaining, avoid bare `except:`, use Pydantic for validation
+- Always mention relevant linting/static analysis: `golangci-lint`, `mypy`, `ruff`
+- Highlight security concerns (SQL injection, missing auth middleware, secrets in code, etc.)
+
+### 2. Step-by-Step Implementation
+- Break the task into clear, numbered steps
+- Show real, runnable code snippets (not pseudocode) with proper imports
+- For Golang: include module path conventions, proper package structure
+- For Python: include virtual env / dependency notes where relevant
+- Call out gotchas and common mistakes at each step
+
+### 3. Clean Architecture & Design Patterns
+- Recommend appropriate patterns: Repository, Service Layer, Middleware chains, Dependency Injection
+- Golang project layout: `cmd/`, `internal/`, `pkg/`, `api/` conventions
+- Python project layout: separate `routers/`, `services/`, `models/`, `repositories/`
+- Keep concerns separated — don't let handlers touch the DB directly
+
+### 4. Performance & Scalability (mention but don't over-engineer)
+- Flag obvious bottlenecks (N+1 queries, missing indexes, sync where async fits)
+- Redis/Kafka: mention caching or event-driven patterns only when genuinely relevant
+- Don't prematurely optimize; call out what to benchmark first
+
+---
+
+## Stack Reference
+
+### Golang
+- **Web**: Gin or Fiber — prefer Gin for stability, Fiber for raw performance
+- **DB**: `pgx` for PostgreSQL, use connection pooling (`pgxpool`)
+- **Redis**: `go-redis/redis`
+- **gRPC**: `google.golang.org/grpc` + `protoc-gen-go`
+- **Config**: `viper` or `godotenv`
+- **Testing**: `testify`, table-driven tests, mocks via `mockery`
+
+### Python
+- **Web**: FastAPI preferred (async, auto-docs), Flask for simpler use cases
+- **DB**: `SQLAlchemy` with `asyncpg` for async, or `psycopg2` for sync
+- **Redis**: `redis-py` or `aioredis`
+- **Kafka**: `confluent-kafka-python`
+- **Validation**: Pydantic v2
+- **Testing**: `pytest`, `pytest-asyncio`, `httpx` for API tests
+
+---
+
+## Output Format for "guide me" Prompts
+
+```
+## Task: <restate the task briefly>
+
+### ⚠️ Watch Out For
+<anti-patterns, gotchas, security notes — always first>
+
+### 🛠 Implementation Steps
+<numbered steps with code>
+
+### 🏗 Architecture Notes
+<design patterns, project structure advice>
+
+### 🚀 Performance Notes
+<only if relevant — skip if not>
+
+### ✅ Checklist
+<3–6 bullet checklist the user can verify against>
+```
+
+---
+
+## Examples of What to Cover
+
+**"guide me to build a REST API endpoint in Go"**
+→ Handler → Service → Repository layers, error wrapping, proper HTTP status codes, middleware for auth/logging, input validation
+
+**"guide me to set up a gRPC server in Python"**
+→ proto file structure, `grpcio-tools` codegen, server setup, interceptors for logging/auth, error codes mapping
+
+**"guide me to add Redis caching to my FastAPI app"**
+→ cache-aside pattern, TTL strategy, cache invalidation approach, async client setup, avoid caching sensitive data
+
+**"guide me to write a CLI tool in Go"**
+→ `cobra` library, subcommand structure, config file vs flags, exit codes, stderr vs stdout discipline
+
+---
+
+## When the Task Is Ambiguous
+
+If a "guide me" prompt is vague, ask **one clarifying question** — the most important one — before
+proceeding. Don't ask multiple questions upfront.

--- a/client/main.go
+++ b/client/main.go
@@ -20,7 +20,7 @@ import (
 // default gRPC port used when user doesn't provide one
 const defaultPort = "50051"
 
-// resolveAddr accepts many forms and returns an address suitable for grpc.Dial,
+// resolveAddr accepts many forms and returns an address suitable for grpc.NewClient,
 // a serverName for TLS verification (if any), and whether to use TLS.
 // Examples accepted:
 //
@@ -90,15 +90,17 @@ func runClient(myID, rawAddr, targetID string) error {
 		// Use system root CAs and verify serverName (SNI)
 		creds := credentials.NewClientTLSFromCert(nil, serverName)
 		dialOpts = append(dialOpts, grpc.WithTransportCredentials(creds))
-		log.Printf("Dialing %s with TLS (serverName=%s)", addr, serverName)
+		log.Printf("connecting to %s with TLS (serverName=%s)", addr, serverName)
 	} else {
 		dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
-		log.Printf("Dialing %s without TLS (insecure)", addr)
+		log.Printf("connecting to %s without TLS (insecure)", addr)
 	}
 
-	conn, err := grpc.Dial(addr, dialOpts...)
+	// grpc.NewClient replaces the deprecated grpc.Dial. Connections are lazy by
+	// default — they’ll be established on the first RPC (IsOnline / Chat below).
+	conn, err := grpc.NewClient(addr, dialOpts...)
 	if err != nil {
-		return err
+		return fmt.Errorf("grpc.NewClient(%q): %w", addr, err)
 	}
 	defer conn.Close()
 

--- a/logs/logger.go
+++ b/logs/logger.go
@@ -2,6 +2,7 @@ package logs
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"time"
 )
@@ -52,35 +53,33 @@ func CloseLogFiles() {
 }
 
 func Logger(log_string string, isErr bool) {
-
-	// Takes the log string and write it into error.logs/access.logs based on isErr
+	// Takes the log string and writes it into error.log/access.log based on isErr.
 	log_dir := GetCurrentLogDir()
 
-	var log_file string
+	log_file := ACCESS_LOG_FILE
 	if isErr {
 		log_file = ERR_LOG_FILE
-	} else {
-		log_file = ACCESS_LOG_FILE
 	}
 
-	_, err := os.Stat(log_dir)
-	if err != nil {
-		os.Mkdir(log_dir, 0777)
+	// MkdirAll is a no-op if the directory exists and creates parents otherwise,
+	// so we don't need a separate Stat probe.
+	if err := os.MkdirAll(log_dir, 0o755); err != nil {
+		log.Printf("logger: cannot create log dir %s: %v", log_dir, err)
+		return
 	}
 
 	log_file_path := fmt.Sprintf("%v/%v", log_dir, log_file)
-	if _, err := os.Stat(log_file_path); err != nil {
-		// Log file does not exit, creating
-		os.Create(log_file_path)
-	}
 
-	// Write the log into the file in append-mode
-	// getting file-object by opening the file
-	f, err := os.OpenFile(log_file_path, os.O_APPEND, 0777)
+	// O_APPEND alone is read-only (RDONLY=0) and Fprintln silently fails on it —
+	// that's why earlier runs produced empty log files. We need WRONLY|APPEND|CREATE.
+	f, err := os.OpenFile(log_file_path, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0o644)
 	if err != nil {
-		panic(err)
+		log.Printf("logger: cannot open %s: %v", log_file_path, err)
+		return
 	}
+	defer f.Close()
 
-	fmt.Fprintln(f, log_string) // Note: Use Fprintln for appending in a newline.
-
+	if _, err := fmt.Fprintln(f, log_string); err != nil {
+		log.Printf("logger: write to %s failed: %v", log_file_path, err)
+	}
 }

--- a/server/main.go
+++ b/server/main.go
@@ -6,7 +6,11 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"os"
+	"os/signal"
+	"slices"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/litG-zen/chat_app/logs"
@@ -83,6 +87,19 @@ func (h *Hub) IsOnline(userID string) bool {
 	return ok
 }
 
+// CloseAll cancels every connected client's context and drains the registry.
+// Used on shutdown so active bidi streams can unwind instead of blocking
+// GracefulStop indefinitely.
+func (h *Hub) CloseAll() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for uid, c := range h.clients {
+		c.cancel()
+		close(c.send)
+		delete(h.clients, uid)
+	}
+}
+
 // deliver to specific users (non-blocking)
 func (h *Hub) SendTo(recipients []string, msg *pb.ChatMessage) {
 	h.mu.RLock()
@@ -102,9 +119,9 @@ func (h *Hub) SendTo(recipients []string, msg *pb.ChatMessage) {
 				Content:   msg.Text,
 				Timestamp: msg.Timestamp,
 			}
-			redis_write_err := utils.AddMessageForUser(message)
-			if redis_write_err != nil {
-				fmt.Errorf("Redis write error %v", redis_write_err)
+			if err := utils.AddMessageForUser(message); err != nil {
+				log.Printf("redis write error for %s: %v", uid, err)
+				logs.Logger(fmt.Sprintf("%v : redis write error for %s: %v", time.Now(), uid, err), true)
 			}
 		}
 	}
@@ -142,12 +159,7 @@ func GetServer() *Server {
 }
 
 func containsStar(recipients []string) bool {
-	for _, r := range recipients {
-		if r == "*" {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(recipients, "*")
 }
 
 func (s *Server) Chat(stream pb.ChatService_ChatServer) error {
@@ -291,13 +303,44 @@ func main() {
 		log.Fatalf("listen failed: %v", err)
 	}
 	grpcServer := grpc.NewServer() // add interceptors / TLS creds in production
-	pb.RegisterChatServiceServer(grpcServer, GetServer())
+	srv := GetServer()
+	pb.RegisterChatServiceServer(grpcServer, srv)
 	log.Println(SERVER_INIT_LOGO)
+	logs.Logger(fmt.Sprintf("%v : Server Bootup!", time.Now()), false)
 
-	log_string := fmt.Sprintf("%v : Server Bootup!", time.Now())
-	logs.Logger(log_string, false)
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- grpcServer.Serve(lis)
+	}()
 
-	if err := grpcServer.Serve(lis); err != nil {
-		log.Fatalf("serve failed: %v", err)
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
+	select {
+	case err := <-serveErr:
+		if err != nil {
+			log.Fatalf("serve failed: %v", err)
+		}
+	case sig := <-sigCh:
+		log.Printf("received %v, shutting down...", sig)
+		logs.Logger(fmt.Sprintf("%v : shutdown signal %v received", time.Now(), sig), false)
+
+		// Force-cancel client streams so handlers return, then let GracefulStop
+		// flush in-flight RPCs. Fall back to Stop() if it drags on.
+		srv.hub.CloseAll()
+
+		done := make(chan struct{})
+		go func() {
+			grpcServer.GracefulStop()
+			close(done)
+		}()
+
+		select {
+		case <-done:
+			log.Println("server stopped gracefully")
+		case <-time.After(10 * time.Second):
+			log.Println("graceful stop timed out, forcing shutdown")
+			grpcServer.Stop()
+		}
 	}
 }

--- a/utils/redisConnector.go
+++ b/utils/redisConnector.go
@@ -6,8 +6,15 @@ import (
 	"fmt"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/go-redis/redis/v8"
+)
+
+const (
+	redisPingTimeout  = 5 * time.Second
+	redisWriteTimeout = 5 * time.Second
+	redisReadTimeout  = 10 * time.Second
 )
 
 var (
@@ -46,10 +53,10 @@ func (r *RedisClient) initialize() error {
 
 	r.client = redis.NewClient(opt)
 
-	// Test connection
-	_, err = r.client.Ping(r.ctx).Result()
-	if err != nil {
-		return fmt.Errorf("failed to connect to redis instance %v", err)
+	pingCtx, cancel := context.WithTimeout(r.ctx, redisPingTimeout)
+	defer cancel()
+	if _, err := r.client.Ping(pingCtx).Result(); err != nil {
+		return fmt.Errorf("failed to connect to redis instance: %w", err)
 	}
 
 	return nil
@@ -75,18 +82,23 @@ func GetRedisInstance() (*RedisClient, error) {
 	return redisClient, nil
 }
 
-// AddMessageForUser adds a serialized message to the recipient's Redis list
+// AddMessageForUser adds a serialized message to the recipient's Redis list.
 func AddMessageForUser(msg RedisMessage) error {
 	rdb, err := GetRedisInstance()
 	if err != nil {
-		return fmt.Errorf("Redis connection issue, please check %v", err)
+		return fmt.Errorf("redis connection issue: %w", err)
 	}
 	jsonMsg, err := json.Marshal(msg)
 	if err != nil {
-		return err
+		return fmt.Errorf("marshal message: %w", err)
 	}
+	ctx, cancel := context.WithTimeout(rdb.ctx, redisWriteTimeout)
+	defer cancel()
 	key := "undelivered:" + msg.Receiver
-	return rdb.client.RPush(rdb.ctx, key, jsonMsg).Err()
+	if err := rdb.client.RPush(ctx, key, jsonMsg).Err(); err != nil {
+		return fmt.Errorf("rpush %s: %w", key, err)
+	}
+	return nil
 }
 
 // FlushMessagesForUser fetches all undelivered messages for a user and deletes the list.
@@ -100,17 +112,29 @@ func FlushMessagesForUser(userID string) ([]RedisMessage, error) {
 		return nil, fmt.Errorf("redis client not initialized")
 	}
 
+	ctx, cancel := context.WithTimeout(rdb.ctx, redisReadTimeout)
+	defer cancel()
+
 	key := "undelivered:" + userID
 
-	// fetch all messages
-	msgsJson, err := rdb.client.LRange(rdb.ctx, key, 0, -1).Result()
-	if err != nil {
-		// If key does not exist, LRange returns nil slice and nil error, so we typically won't hit this,
-		// but handle any other redis errors here.
-		return nil, fmt.Errorf("failed to lrange key %s: %w", key, err)
+	// LRange + Del executed in a MULTI/EXEC transaction so messages can't be
+	// pushed between the read and the delete (any concurrent RPush after EXEC
+	// stays in the new list and is delivered next time).
+	var lrangeCmd *redis.StringSliceCmd
+	if _, err := rdb.client.TxPipelined(ctx, func(p redis.Pipeliner) error {
+		lrangeCmd = p.LRange(ctx, key, 0, -1)
+		p.Del(ctx, key)
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("flush pipeline for %s: %w", key, err)
 	}
 
-	var msgs []RedisMessage
+	msgsJson, err := lrangeCmd.Result()
+	if err != nil {
+		return nil, fmt.Errorf("lrange %s: %w", key, err)
+	}
+
+	msgs := make([]RedisMessage, 0, len(msgsJson))
 	for _, m := range msgsJson {
 		var msg RedisMessage
 		if err := json.Unmarshal([]byte(m), &msg); err != nil {
@@ -118,12 +142,6 @@ func FlushMessagesForUser(userID string) ([]RedisMessage, error) {
 			continue
 		}
 		msgs = append(msgs, msg)
-	}
-
-	// delete the list atomically after reading
-	if err := rdb.client.Del(rdb.ctx, key).Err(); err != nil {
-		// we read the messages successfully — return them but also surface the delete error
-		return msgs, fmt.Errorf("fetched %d messages but failed to delete key %s: %w", len(msgs), key, err)
 	}
 
 	return msgs, nil


### PR DESCRIPTION
## Summary
Hardens error handling, shutdown semantics, and the Redis-backed offline message queue across the chat server, client, logger, and Redis util. No behavioural change to the happy path; failure modes that previously went silent now surface, and shutdown stops being a SIGKILL-only affair. Also adds CLAUDE.md so future Claude Code sessions in this repo follow a consistent review/guide format.

# What's changed
`server/main.go`
- Redis write errors no longer dropped. The previous code called fmt.Errorf(...) and discarded the return value, so persistence failures for offline users were invisible. Now logged via both log.Printf and logs.Logger.
- Graceful shutdown. main runs grpc.Serve in a goroutine, listens for SIGINT/SIGTERM, and on signal calls a new Hub.CloseAll() to cancel every client's context before GracefulStop() — with a 10 s fallback to Stop() so a hung stream can't block exit forever.
- containsStar → slices.Contains (vet hint).

`client/main.go`
- Migrated off the deprecated grpc.Dial to grpc.NewClient. Connections are lazy by default and established on the first RPC.
- Error from NewClient now wrapped with %w for proper unwrapping.
utils/redisConnector.go
- Per-call context timeouts on Ping (5 s), RPush (5 s), and the flush path (10 s) — a slow/hung Redis can no longer stall the join flow indefinitely.
- Race fix in FlushMessagesForUser. The old code did LRange then Del, leaving a window where a concurrent RPush could land between the two and get destroyed. Replaced with a TxPipelined MULTI/EXEC so the read and delete are atomic.
- All Redis errors wrapped with %w.

`logs/logger.go`
- Fixed silent data-loss bug. os.OpenFile(path, os.O_APPEND, 0777) opens the file read-only (O_RDONLY == 0), so fmt.Fprintln was a no-op and the write error was swallowed. Now O_APPEND | O_WRONLY | O_CREATE.
- os.Mkdir → os.MkdirAll (handles missing parent logs/ dir on fresh checkouts).
- Replaced the panic on open failure with log.Printf — a log-write failure shouldn't crash the server.
- File now properly defer f.Close()'d.

`Test plan`
 go build ./... passes
 go vet ./... clean
 Manual: start server, connect two clients, exchange messages, confirm normal flow unchanged
 Manual: kill one client, send to that user, restart it, confirm the queued message is delivered exactly once
 Manual: Ctrl+C the server with a client connected, confirm it exits within ~10 s and the client gets a clean stream close
 Manual: tail logs/<today>/access.log to verify lines are now actually being written (previously empty due to the O_APPEND bug)
Explicitly out of scope
TLS / auth on the gRPC server. Needs decisions on mTLS vs token-based, key storage, and interceptor design — separate PR.
Multi-node Hub. Requires picking a fan-out backplane (Redis pub/sub, NATS, Kafka) and a presence store — architectural shift, separate PR.


<img width="2874" height="1664" alt="Screenshot 2026-05-23 180217" src="https://github.com/user-attachments/assets/931f002a-8d90-4ea0-94c3-f0a6267a980c" />
