### PR TITLE
feat(presence): Redis-backed presence service and typing indicators

### DIFF
--- a/.claude/agents/security_agent.md
+++ b/.claude/agents/security_agent.md
@@ -1,0 +1,14 @@
+.claude/agents/security_agent.md
+---
+name: security-reviewer
+description: Expert code reviewer for security vulnerabilities. Use PROACTIVELY when reviewing PRs or before deployments.
+model: sonnet
+tools: Read, Grep, Glob
+---
+
+You are a senior security engineer. When reviewing code:
+- Flag bugs, not just style issues
+- Check for SQL injection and XSS risks
+- Look for exposed credentials or secrets
+- Check authentication and authorization gaps
+- Note performance concerns only when they matter at scale

--- a/.claude/skills/realtime.md
+++ b/.claude/skills/realtime.md
@@ -1,0 +1,11 @@
+## Realtime Event Rules
+
+- Typing events are ephemeral; never persist in DB unless analytics requires it.
+- Use TTL-based expiration (ex: 2–5s).
+- Debounce frequent typing updates.
+- Avoid per-keystroke network sends.
+- Broadcast only to room participants.
+- Handle stale sessions after disconnect.
+- Support idempotent event handling.
+- Prefer server-authoritative presence state.
+- Separate message events from transient events.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,112 +1,126 @@
-# Backend Engineering Lead
+# Senior Golang Distributed Systems Engineer
 
-You are acting as a **Senior Backend Engineering Lead** — a trusted technical mentor for personal
-projects in **Golang** and **Python**. Your guidance should feel like a senior engineer doing a
-thorough code/design review, not generic documentation.
+You are acting as a **Principal Backend Engineer**
+reviewing and guiding development of a **production-grade asynchronous chat system in Golang using gRPC**.
+
+Focus on correctness, scalability, concurrency safety, and production readiness.
 
 ---
 
 ## Behaviour
 
-- Direct, opinionated, and practical — like a senior engineer on a team
-- Assume the user is a capable developer; skip beginner basics unless asked
-- Use "we" framing when appropriate ("here's how we'd approach this...")
-- Be concise but complete — no filler, no padding
-- When a prompt starts with **"guide me"**, always respond using the full structured format below
+- Direct, practical, opinionated
+- Assume user is an experienced developer
+- Skip beginner explanations unless asked
+- Prefer clarity over cleverness
+- Flag design flaws immediately
+- Be concise but technically deep
+- Use "we" framing when helpful
+- If prompt starts with **"guide me"**, follow structured response format
 
 ---
 
-## Response Priority Order
+## Review Priority Order
 
-When guiding on any task, structure your response in this order:
+### 1. Correctness & Safety (TOP PRIORITY)
 
-### 1. Code Review & Best Practices (TOP PRIORITY)
-- Flag anti-patterns, bad naming, improper error handling, or missing validations upfront
-- Golang: proper error wrapping (`fmt.Errorf("context: %w", err)`), avoid naked returns, use `context.Context` propagation
-- Python: type hints everywhere, proper exception chaining, avoid bare `except:`, use Pydantic for validation
-- Always mention relevant linting/static analysis: `golangci-lint`, `mypy`, `ruff`
-- Highlight security concerns (SQL injection, missing auth middleware, secrets in code, etc.)
+Always review for:
 
-### 2. Step-by-Step Implementation
-- Break the task into clear, numbered steps
-- Show real, runnable code snippets (not pseudocode) with proper imports
-- For Golang: include module path conventions, proper package structure
-- For Python: include virtual env / dependency notes where relevant
-- Call out gotchas and common mistakes at each step
+#### Concurrency
+- goroutine leaks
+- unbounded channels
+- deadlocks
+- race conditions
+- shared map writes
+- mutex misuse
+- blocking handlers
+- improper `context.Context` propagation
 
-### 3. Clean Architecture & Design Patterns
-- Recommend appropriate patterns: Repository, Service Layer, Middleware chains, Dependency Injection
-- Golang project layout: `cmd/`, `internal/`, `pkg/`, `api/` conventions
-- Python project layout: separate `routers/`, `services/`, `models/`, `repositories/`
-- Keep concerns separated — don't let handlers touch the DB directly
+#### Error Handling
+- wrap errors: `fmt.Errorf("context: %w", err)`
+- never swallow errors
+- distinguish retryable vs permanent failures
 
-### 4. Performance & Scalability (mention but don't over-engineer)
-- Flag obvious bottlenecks (N+1 queries, missing indexes, sync where async fits)
-- Redis/Kafka: mention caching or event-driven patterns only when genuinely relevant
-- Don't prematurely optimize; call out what to benchmark first
-
----
-
-## Stack Reference
-
-### Golang
-- **Web**: Gin or Fiber — prefer Gin for stability, Fiber for raw performance
-- **DB**: `pgx` for PostgreSQL, use connection pooling (`pgxpool`)
-- **Redis**: `go-redis/redis`
-- **gRPC**: `google.golang.org/grpc` + `protoc-gen-go`
-- **Config**: `viper` or `godotenv`
-- **Testing**: `testify`, table-driven tests, mocks via `mockery`
-
-### Python
-- **Web**: FastAPI preferred (async, auto-docs), Flask for simpler use cases
-- **DB**: `SQLAlchemy` with `asyncpg` for async, or `psycopg2` for sync
-- **Redis**: `redis-py` or `aioredis`
-- **Kafka**: `confluent-kafka-python`
-- **Validation**: Pydantic v2
-- **Testing**: `pytest`, `pytest-asyncio`, `httpx` for API tests
+#### Security
+- auth propagation
+- gRPC metadata validation
+- input validation
+- rate limiting
+- secret handling
+- authorization boundaries
 
 ---
 
-## Output Format for "guide me" Prompts
+### 2. gRPC Best Practices
 
-```
-## Task: <restate the task briefly>
+Evaluate for:
 
-### ⚠️ Watch Out For
-<anti-patterns, gotchas, security notes — always first>
+#### API Design
+- unary vs streaming tradeoffs
+- bidirectional streams for chat transport
+- protobuf compatibility/versioning
+- request idempotency
+- pagination where needed
 
-### 🛠 Implementation Steps
-<numbered steps with code>
+#### Reliability
+- deadlines / timeouts
+- retries
+- keepalive / heartbeat
+- reconnect strategy
+- partial failure handling
 
-### 🏗 Architecture Notes
-<design patterns, project structure advice>
+#### Interceptors
+Prefer:
+- auth
+- logging
+- metrics
+- tracing
+- panic recovery
 
-### 🚀 Performance Notes
-<only if relevant — skip if not>
-
-### ✅ Checklist
-<3–6 bullet checklist the user can verify against>
-```
+#### Error Codes
+Use proper gRPC status codes:
+- InvalidArgument
+- Unauthenticated
+- PermissionDenied
+- NotFound
+- ResourceExhausted
+- Unavailable
+- Internal
 
 ---
 
-## Examples of What to Cover
+### 3. Distributed Chat Architecture
 
-**"guide me to build a REST API endpoint in Go"**
-→ Handler → Service → Repository layers, error wrapping, proper HTTP status codes, middleware for auth/logging, input validation
+Default mental model:
 
-**"guide me to set up a gRPC server in Python"**
-→ proto file structure, `grpcio-tools` codegen, server setup, interceptors for logging/auth, error codes mapping
+Client
+→ Gateway
+→ Chat Service
+→ PubSub/Broker
+→ Presence
+→ Storage
+→ Notifications
 
-**"guide me to add Redis caching to my FastAPI app"**
-→ cache-aside pattern, TTL strategy, cache invalidation approach, async client setup, avoid caching sensitive data
+Check for:
 
-**"guide me to write a CLI tool in Go"**
-→ `cobra` library, subcommand structure, config file vs flags, exit codes, stderr vs stdout discipline
+#### Message Flow
+- ordering guarantees
+- deduplication
+- retry safety
+- fanout strategy
+- replay handling
 
----
+#### Async Delivery
+- offline users
+- durable queues
+- acknowledgements
+- redelivery
+- backpressure
+- dead-letter queues
 
-## When the Task Is Ambiguous
+#### Scale
+- hot partitions
+- sharding
+- sticky sessions
+- connection balancing
 
-If a "guide me" prompt is vague, ask **one clarifying question** — the most important one — before
-proceeding. Don't ask multiple questions upfront.

--- a/client/main.go
+++ b/client/main.go
@@ -168,8 +168,8 @@ func runClient(myID, rawAddr, targetID string) error {
 				}
 			case pb.MessageType_TYPING_START:
 				fmt.Printf("\n-- %s is typing... --\n> ", in.UserId)
-			case pb.MessageType_TYPING_STOP:
-				fmt.Printf("\n-- %s stopped typing --\n> ", in.UserId)
+			// case pb.MessageType_TYPING_STOP:
+			// 	fmt.Printf("\n-- %s stopped typing --\n> ", in.UserId)
 			default:
 				fmt.Printf("\n<< [%s] %s\n> ", in.UserId, in.Text)
 			}

--- a/client/main.go
+++ b/client/main.go
@@ -136,6 +136,20 @@ func runClient(myID, rawAddr, targetID string) error {
 		return fmt.Errorf("failed to send join: %w", err)
 	}
 
+	// Subscribe to the target's presence so we get ONLINE/OFFLINE updates on
+	// this stream. Skipped in broadcast mode where there is no single target.
+	if targetID != "*" {
+		sub := &pb.ChatMessage{
+			UserId:    myID,
+			To:        []string{targetID},
+			Type:      pb.MessageType_PRESENCE_SUBSCRIBE,
+			Timestamp: time.Now().UnixNano() / int64(time.Millisecond),
+		}
+		if err := stream.Send(sub); err != nil {
+			log.Printf("warning: failed to subscribe to presence for %s: %v", targetID, err)
+		}
+	}
+
 	go func() {
 		for {
 			in, err := stream.Recv()
@@ -143,7 +157,22 @@ func runClient(myID, rawAddr, targetID string) error {
 				log.Println("stream.Recv error:", err)
 				return
 			}
-			fmt.Printf("\n<< [%s] %s\n> ", in.UserId, in.Text)
+			switch in.Type {
+			case pb.MessageType_PRESENCE_ONLINE:
+				fmt.Printf("\n-- %s is online --\n> ", in.UserId)
+			case pb.MessageType_PRESENCE_OFFLINE:
+				if in.Text == "subscription_limit" {
+					fmt.Printf("\n-- subscription limit reached; cannot watch %s --\n> ", in.UserId)
+				} else {
+					fmt.Printf("\n-- %s is offline --\n> ", in.UserId)
+				}
+			case pb.MessageType_TYPING_START:
+				fmt.Printf("\n-- %s is typing... --\n> ", in.UserId)
+			case pb.MessageType_TYPING_STOP:
+				fmt.Printf("\n-- %s stopped typing --\n> ", in.UserId)
+			default:
+				fmt.Printf("\n<< [%s] %s\n> ", in.UserId, in.Text)
+			}
 		}
 	}()
 
@@ -163,12 +192,44 @@ func runClient(myID, rawAddr, targetID string) error {
 				Instead of reading one byte at a time from stdin, it grabs chunks into memory and lets you work line by line, string by string.
 	*/
 	fmt.Println("Type messages and press Enter. Ctrl+C to exit.")
+	// Typing indicator is a CLI heuristic: we emit TYPING_START right after
+	// drawing the prompt (we don't see keystrokes — stdin is line-buffered)
+	// and TYPING_STOP just before the MESSAGE goes out. Server-side TTL
+	// covers the "user walked away from prompt" case. Broadcast mode skips
+	// typing events entirely since there is no single recipient.
+	isDM := targetID != "*"
 	for {
+		if isDM {
+			startMsg := &pb.ChatMessage{
+				UserId:    myID,
+				To:        []string{targetID},
+				Type:      pb.MessageType_TYPING_START,
+				Timestamp: time.Now().UnixNano() / int64(time.Millisecond),
+			}
+			if err := stream.Send(startMsg); err != nil {
+				log.Println("typing_start send error:", err)
+				break
+			}
+		}
+
 		fmt.Print("> ")
 		line, err := reader.ReadString('\n')
 		if err != nil {
 			log.Println("read error:", err)
 			break
+		}
+
+		if isDM {
+			stopMsg := &pb.ChatMessage{
+				UserId:    myID,
+				To:        []string{targetID},
+				Type:      pb.MessageType_TYPING_STOP,
+				Timestamp: time.Now().UnixNano() / int64(time.Millisecond),
+			}
+			if err := stream.Send(stopMsg); err != nil {
+				log.Println("typing_stop send error:", err)
+				break
+			}
 		}
 
 		toField := []string{targetID}

--- a/presence/manager.go
+++ b/presence/manager.go
@@ -1,0 +1,180 @@
+package presence
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"sync"
+
+	"github.com/go-redis/redis/v8"
+)
+
+// PresenceCallback is invoked on every PresenceEvent received from Redis,
+// already enriched with the list of locally-connected watchers interested in
+// ev.UserID. If watchers is empty the callback should be a no-op.
+type PresenceCallback func(ev PresenceEvent, watchers []string)
+
+// TypingCallback is invoked on every TypingEvent received from Redis. The
+// callback should fan out to whichever recipients in ev.To are connected to
+// this node.
+type TypingCallback func(ev TypingEvent)
+
+// Manager is the public surface for the presence subsystem. One instance per
+// server process. Safe for concurrent use.
+type Manager struct {
+	store    *store
+	watchers *watcherIndex
+
+	startOnce sync.Once
+	startErr  error
+
+	cbMu       sync.RWMutex
+	onPresence PresenceCallback
+	onTyping   TypingCallback
+
+	// pubsub handles are retained for clean shutdown.
+	presenceSub *redis.PubSub
+	typingSub   *redis.PubSub
+}
+
+func NewManager(rdb *redis.Client, nodeID string) *Manager {
+	return &Manager{
+		store:    newStore(rdb, nodeID),
+		watchers: newWatcherIndex(),
+	}
+}
+
+// Start launches the two subscriber goroutines. Subsequent calls are no-ops.
+// The goroutines exit when ctx is canceled.
+func (m *Manager) Start(ctx context.Context) error {
+	m.startOnce.Do(func() {
+		m.presenceSub = m.store.rdb.Subscribe(ctx, PresenceChannel)
+		m.typingSub = m.store.rdb.Subscribe(ctx, TypingChannel)
+
+		// Block on first receive to surface immediate connection errors.
+		if _, err := m.presenceSub.Receive(ctx); err != nil {
+			m.startErr = fmt.Errorf("subscribe presence channel: %w", err)
+			return
+		}
+		if _, err := m.typingSub.Receive(ctx); err != nil {
+			m.startErr = fmt.Errorf("subscribe typing channel: %w", err)
+			return
+		}
+
+		go m.consumePresence(ctx)
+		go m.consumeTyping(ctx)
+	})
+	return m.startErr
+}
+
+func (m *Manager) consumePresence(ctx context.Context) {
+	ch := m.presenceSub.Channel()
+	for {
+		select {
+		case <-ctx.Done():
+			_ = m.presenceSub.Close()
+			return
+		case msg, ok := <-ch:
+			if !ok {
+				return
+			}
+			var ev PresenceEvent
+			if err := json.Unmarshal([]byte(msg.Payload), &ev); err != nil {
+				log.Printf("presence: malformed presence event: %v", err)
+				continue
+			}
+			watchers := m.watchers.WatchersOf(ev.UserID)
+			if len(watchers) == 0 {
+				continue
+			}
+			m.cbMu.RLock()
+			cb := m.onPresence
+			m.cbMu.RUnlock()
+			if cb != nil {
+				cb(ev, watchers)
+			}
+		}
+	}
+}
+
+func (m *Manager) consumeTyping(ctx context.Context) {
+	ch := m.typingSub.Channel()
+	for {
+		select {
+		case <-ctx.Done():
+			_ = m.typingSub.Close()
+			return
+		case msg, ok := <-ch:
+			if !ok {
+				return
+			}
+			var ev TypingEvent
+			if err := json.Unmarshal([]byte(msg.Payload), &ev); err != nil {
+				log.Printf("presence: malformed typing event: %v", err)
+				continue
+			}
+			m.cbMu.RLock()
+			cb := m.onTyping
+			m.cbMu.RUnlock()
+			if cb != nil {
+				cb(ev)
+			}
+		}
+	}
+}
+
+func (m *Manager) OnPresenceEvent(fn PresenceCallback) {
+	m.cbMu.Lock()
+	m.onPresence = fn
+	m.cbMu.Unlock()
+}
+
+func (m *Manager) OnTypingEvent(fn TypingCallback) {
+	m.cbMu.Lock()
+	m.onTyping = fn
+	m.cbMu.Unlock()
+}
+
+func (m *Manager) MarkOnline(ctx context.Context, userID string) error {
+	return m.store.MarkOnline(ctx, userID)
+}
+
+func (m *Manager) MarkOffline(ctx context.Context, userID string) error {
+	return m.store.MarkOffline(ctx, userID)
+}
+
+func (m *Manager) RefreshTTL(ctx context.Context, userID string) error {
+	return m.store.RefreshTTL(ctx, userID)
+}
+
+func (m *Manager) IsOnline(ctx context.Context, userID string) (bool, error) {
+	return m.store.IsOnline(ctx, userID)
+}
+
+func (m *Manager) PublishTyping(ctx context.Context, ev TypingEvent) error {
+	return m.store.PublishTyping(ctx, ev)
+}
+
+// AddWatcher registers watcher's interest in watched. Returns
+// ErrSubscriptionLimit if the watcher exceeds MaxSubscriptionsPerClient.
+func (m *Manager) AddWatcher(watcher, watched string) error {
+	return m.watchers.Add(watcher, watched)
+}
+
+// RemoveAllWatchers drops every interest entry the watcher holds.
+func (m *Manager) RemoveAllWatchers(watcher string) {
+	m.watchers.RemoveWatcher(watcher)
+}
+
+// CountFor reports how many users the watcher is currently subscribed to.
+func (m *Manager) CountFor(watcher string) int {
+	return m.watchers.CountFor(watcher)
+}
+
+// IsSubscriptionLimit reports whether err originated from the per-client
+// subscription cap. Useful for the server to map to a gRPC status code.
+func IsSubscriptionLimit(err error) bool {
+	return errors.Is(err, ErrSubscriptionLimit)
+}

--- a/presence/store.go
+++ b/presence/store.go
@@ -1,0 +1,112 @@
+package presence
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/go-redis/redis/v8"
+)
+
+const (
+	PresenceKeyPrefix = "presence:"
+	PresenceChannel   = "presence:events"
+	TypingChannel     = "typing:events"
+
+	// TTL on the presence key; refreshed by heartbeat. If a server crashes
+	// mid-stream, the key expires within this window and the user flips to
+	// offline. Refresh interval must be < TTL/2 to tolerate one missed tick.
+	PresenceTTL     = 30 * time.Second
+	RefreshInterval = 10 * time.Second
+)
+
+type store struct {
+	rdb    *redis.Client
+	nodeID string
+}
+
+func newStore(rdb *redis.Client, nodeID string) *store {
+	return &store{rdb: rdb, nodeID: nodeID}
+}
+
+func presenceKey(userID string) string {
+	return PresenceKeyPrefix + userID
+}
+
+func (s *store) MarkOnline(ctx context.Context, userID string) error {
+	if err := s.rdb.Set(ctx, presenceKey(userID), s.nodeID, PresenceTTL).Err(); err != nil {
+		return fmt.Errorf("set presence key for %s: %w", userID, err)
+	}
+	return s.publishPresence(ctx, PresenceEvent{
+		UserID:    userID,
+		State:     StateOnline,
+		Timestamp: nowMillis(),
+		NodeID:    s.nodeID,
+	})
+}
+
+func (s *store) MarkOffline(ctx context.Context, userID string) error {
+	if err := s.rdb.Del(ctx, presenceKey(userID)).Err(); err != nil {
+		return fmt.Errorf("del presence key for %s: %w", userID, err)
+	}
+	return s.publishPresence(ctx, PresenceEvent{
+		UserID:    userID,
+		State:     StateOffline,
+		Timestamp: nowMillis(),
+		NodeID:    s.nodeID,
+	})
+}
+
+func (s *store) RefreshTTL(ctx context.Context, userID string) error {
+	ok, err := s.rdb.Expire(ctx, presenceKey(userID), PresenceTTL).Result()
+	if err != nil {
+		return fmt.Errorf("expire presence key for %s: %w", userID, err)
+	}
+	if !ok {
+		// Key vanished — likely TTL elapsed because the heartbeat fell behind.
+		// Restore it so we don't flap the user offline.
+		if err := s.rdb.Set(ctx, presenceKey(userID), s.nodeID, PresenceTTL).Err(); err != nil {
+			return fmt.Errorf("restore presence key for %s: %w", userID, err)
+		}
+	}
+	return nil
+}
+
+func (s *store) IsOnline(ctx context.Context, userID string) (bool, error) {
+	n, err := s.rdb.Exists(ctx, presenceKey(userID)).Result()
+	if err != nil {
+		return false, fmt.Errorf("exists presence key for %s: %w", userID, err)
+	}
+	return n > 0, nil
+}
+
+func (s *store) PublishTyping(ctx context.Context, ev TypingEvent) error {
+	ev.NodeID = s.nodeID
+	if ev.Timestamp == 0 {
+		ev.Timestamp = nowMillis()
+	}
+	payload, err := json.Marshal(ev)
+	if err != nil {
+		return fmt.Errorf("marshal typing event: %w", err)
+	}
+	if err := s.rdb.Publish(ctx, TypingChannel, payload).Err(); err != nil {
+		return fmt.Errorf("publish typing event: %w", err)
+	}
+	return nil
+}
+
+func (s *store) publishPresence(ctx context.Context, ev PresenceEvent) error {
+	payload, err := json.Marshal(ev)
+	if err != nil {
+		return fmt.Errorf("marshal presence event: %w", err)
+	}
+	if err := s.rdb.Publish(ctx, PresenceChannel, payload).Err(); err != nil {
+		return fmt.Errorf("publish presence event: %w", err)
+	}
+	return nil
+}
+
+func nowMillis() int64 {
+	return time.Now().UnixNano() / int64(time.Millisecond)
+}

--- a/presence/types.go
+++ b/presence/types.go
@@ -1,0 +1,30 @@
+package presence
+
+type PresenceState string
+
+const (
+	StateOnline  PresenceState = "online"
+	StateOffline PresenceState = "offline"
+)
+
+type TypingState string
+
+const (
+	TypingStart TypingState = "start"
+	TypingStop  TypingState = "stop"
+)
+
+type PresenceEvent struct {
+	UserID    string        `json:"user_id"`
+	State     PresenceState `json:"state"`
+	Timestamp int64         `json:"ts"`
+	NodeID    string        `json:"node_id,omitempty"`
+}
+
+type TypingEvent struct {
+	From      string      `json:"from"`
+	To        []string    `json:"to"`
+	State     TypingState `json:"state"`
+	Timestamp int64       `json:"ts"`
+	NodeID    string      `json:"node_id,omitempty"`
+}

--- a/presence/watchers.go
+++ b/presence/watchers.go
@@ -1,0 +1,106 @@
+package presence
+
+import (
+	"errors"
+	"sync"
+)
+
+// MaxSubscriptionsPerClient caps how many users a single client can watch.
+// Prevents a malicious / buggy client from exploding server memory.
+const MaxSubscriptionsPerClient = 1000
+
+var ErrSubscriptionLimit = errors.New("subscription limit reached")
+
+// watcherIndex maintains a bidirectional mapping between watchers and the users
+// they observe. Both directions are kept consistent under a single mutex.
+//
+//	watched -> set of watchers  : used when an event for `watched` arrives and
+//	                              we need to find local clients to deliver to.
+//	watcher -> set of watched   : used on watcher disconnect to clean up O(N).
+type watcherIndex struct {
+	mu          sync.RWMutex
+	watchersOf  map[string]map[string]struct{} // watched -> watchers
+	watchedBy   map[string]map[string]struct{} // watcher -> watched
+}
+
+func newWatcherIndex() *watcherIndex {
+	return &watcherIndex{
+		watchersOf: make(map[string]map[string]struct{}),
+		watchedBy:  make(map[string]map[string]struct{}),
+	}
+}
+
+// Add registers watcher's interest in watched. Returns ErrSubscriptionLimit
+// if watcher already observes MaxSubscriptionsPerClient distinct users.
+// Idempotent: re-adding an existing pair is a no-op and does not count.
+func (w *watcherIndex) Add(watcher, watched string) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if existing, ok := w.watchedBy[watcher]; ok {
+		if _, already := existing[watched]; already {
+			return nil
+		}
+		if len(existing) >= MaxSubscriptionsPerClient {
+			return ErrSubscriptionLimit
+		}
+	}
+
+	if w.watchersOf[watched] == nil {
+		w.watchersOf[watched] = make(map[string]struct{})
+	}
+	w.watchersOf[watched][watcher] = struct{}{}
+
+	if w.watchedBy[watcher] == nil {
+		w.watchedBy[watcher] = make(map[string]struct{})
+	}
+	w.watchedBy[watcher][watched] = struct{}{}
+
+	return nil
+}
+
+// RemoveWatcher drops watcher from every watched set it appears in. Called on
+// stream close so we don't leak interest entries.
+func (w *watcherIndex) RemoveWatcher(watcher string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	watched, ok := w.watchedBy[watcher]
+	if !ok {
+		return
+	}
+	for target := range watched {
+		if peers, exists := w.watchersOf[target]; exists {
+			delete(peers, watcher)
+			if len(peers) == 0 {
+				delete(w.watchersOf, target)
+			}
+		}
+	}
+	delete(w.watchedBy, watcher)
+}
+
+// WatchersOf returns a snapshot of watcher IDs interested in `watched`.
+// Returned slice is safe to use after the mutex is released.
+func (w *watcherIndex) WatchersOf(watched string) []string {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+
+	peers, ok := w.watchersOf[watched]
+	if !ok || len(peers) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(peers))
+	for id := range peers {
+		out = append(out, id)
+	}
+	return out
+}
+
+// CountFor returns how many users `watcher` is currently subscribed to.
+// Useful for tests; not on the hot path.
+func (w *watcherIndex) CountFor(watcher string) int {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	return len(w.watchedBy[watcher])
+}

--- a/presence/watchers_test.go
+++ b/presence/watchers_test.go
@@ -1,0 +1,105 @@
+package presence
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+func TestWatcherIndex_AddIsIdempotent(t *testing.T) {
+	idx := newWatcherIndex()
+	if err := idx.Add("alice", "bob"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := idx.Add("alice", "bob"); err != nil {
+		t.Fatalf("re-Add: %v", err)
+	}
+	if got, want := idx.CountFor("alice"), 1; got != want {
+		t.Fatalf("CountFor(alice) = %d, want %d", got, want)
+	}
+	if peers := idx.WatchersOf("bob"); len(peers) != 1 || peers[0] != "alice" {
+		t.Fatalf("WatchersOf(bob) = %v, want [alice]", peers)
+	}
+}
+
+func TestWatcherIndex_SubscriptionLimit(t *testing.T) {
+	idx := newWatcherIndex()
+	for i := 0; i < MaxSubscriptionsPerClient; i++ {
+		if err := idx.Add("alice", fmt.Sprintf("u%d", i)); err != nil {
+			t.Fatalf("Add %d: %v", i, err)
+		}
+	}
+	err := idx.Add("alice", "overflow")
+	if err == nil {
+		t.Fatal("expected ErrSubscriptionLimit, got nil")
+	}
+	if !IsSubscriptionLimit(err) {
+		t.Fatalf("expected ErrSubscriptionLimit, got %v", err)
+	}
+	if got, want := idx.CountFor("alice"), MaxSubscriptionsPerClient; got != want {
+		t.Fatalf("CountFor(alice) = %d, want %d", got, want)
+	}
+}
+
+func TestWatcherIndex_RemoveCleansBothDirections(t *testing.T) {
+	idx := newWatcherIndex()
+	_ = idx.Add("alice", "bob")
+	_ = idx.Add("alice", "carol")
+	_ = idx.Add("dan", "bob")
+
+	idx.RemoveWatcher("alice")
+
+	if got := idx.CountFor("alice"); got != 0 {
+		t.Fatalf("CountFor(alice) after remove = %d, want 0", got)
+	}
+	peers := idx.WatchersOf("bob")
+	if len(peers) != 1 || peers[0] != "dan" {
+		t.Fatalf("WatchersOf(bob) after remove = %v, want [dan]", peers)
+	}
+	if peers := idx.WatchersOf("carol"); len(peers) != 0 {
+		t.Fatalf("WatchersOf(carol) after remove = %v, want []", peers)
+	}
+}
+
+func TestWatcherIndex_ConcurrentAddRemove(t *testing.T) {
+	idx := newWatcherIndex()
+	const workers = 32
+	const opsPerWorker = 200
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for w := 0; w < workers; w++ {
+		go func(id int) {
+			defer wg.Done()
+			watcher := fmt.Sprintf("w%d", id)
+			for i := 0; i < opsPerWorker; i++ {
+				target := fmt.Sprintf("t%d", i%50)
+				_ = idx.Add(watcher, target)
+				_ = idx.WatchersOf(target)
+			}
+			idx.RemoveWatcher(watcher)
+		}(w)
+	}
+	wg.Wait()
+
+	for w := 0; w < workers; w++ {
+		if got := idx.CountFor(fmt.Sprintf("w%d", w)); got != 0 {
+			t.Fatalf("watcher w%d not cleaned up: %d entries remain", w, got)
+		}
+	}
+	for i := 0; i < 50; i++ {
+		if peers := idx.WatchersOf(fmt.Sprintf("t%d", i)); len(peers) != 0 {
+			t.Fatalf("t%d still has watchers: %v", i, peers)
+		}
+	}
+}
+
+func TestWatcherIndex_ReAddAfterLimitFails(t *testing.T) {
+	idx := newWatcherIndex()
+	for i := 0; i < MaxSubscriptionsPerClient; i++ {
+		_ = idx.Add("alice", fmt.Sprintf("u%d", i))
+	}
+	if err := idx.Add("alice", "u0"); err != nil {
+		t.Fatalf("re-Add of existing pair at cap should succeed (idempotent), got %v", err)
+	}
+}

--- a/proto/chat.pb.go
+++ b/proto/chat.pb.go
@@ -24,34 +24,49 @@ const (
 type MessageType int32
 
 const (
-	MessageType_UNKNOWN MessageType = 0
-	MessageType_JOIN    MessageType = 1
-	MessageType_LEAVE   MessageType = 2
-	MessageType_MESSAGE MessageType = 3
-	MessageType_TYPING  MessageType = 4
-	MessageType_PING    MessageType = 5
-	MessageType_PONG    MessageType = 6
+	MessageType_UNKNOWN            MessageType = 0
+	MessageType_JOIN               MessageType = 1
+	MessageType_LEAVE              MessageType = 2
+	MessageType_MESSAGE            MessageType = 3
+	MessageType_TYPING             MessageType = 4 // deprecated; superseded by TYPING_START / TYPING_STOP
+	MessageType_PING               MessageType = 5
+	MessageType_PONG               MessageType = 6
+	MessageType_TYPING_START       MessageType = 7  // sender began composing; To = recipients
+	MessageType_TYPING_STOP        MessageType = 8  // sender stopped composing; To = recipients
+	MessageType_PRESENCE_ONLINE    MessageType = 9  // server -> watcher: user_id came online
+	MessageType_PRESENCE_OFFLINE   MessageType = 10 // server -> watcher: user_id went offline
+	MessageType_PRESENCE_SUBSCRIBE MessageType = 11 // client -> server: To = user_ids to watch
 )
 
 // Enum value maps for MessageType.
 var (
 	MessageType_name = map[int32]string{
-		0: "UNKNOWN",
-		1: "JOIN",
-		2: "LEAVE",
-		3: "MESSAGE",
-		4: "TYPING",
-		5: "PING",
-		6: "PONG",
+		0:  "UNKNOWN",
+		1:  "JOIN",
+		2:  "LEAVE",
+		3:  "MESSAGE",
+		4:  "TYPING",
+		5:  "PING",
+		6:  "PONG",
+		7:  "TYPING_START",
+		8:  "TYPING_STOP",
+		9:  "PRESENCE_ONLINE",
+		10: "PRESENCE_OFFLINE",
+		11: "PRESENCE_SUBSCRIBE",
 	}
 	MessageType_value = map[string]int32{
-		"UNKNOWN": 0,
-		"JOIN":    1,
-		"LEAVE":   2,
-		"MESSAGE": 3,
-		"TYPING":  4,
-		"PING":    5,
-		"PONG":    6,
+		"UNKNOWN":            0,
+		"JOIN":               1,
+		"LEAVE":              2,
+		"MESSAGE":            3,
+		"TYPING":             4,
+		"PING":               5,
+		"PONG":               6,
+		"TYPING_START":       7,
+		"TYPING_STOP":        8,
+		"PRESENCE_ONLINE":    9,
+		"PRESENCE_OFFLINE":   10,
+		"PRESENCE_SUBSCRIBE": 11,
 	}
 )
 
@@ -269,7 +284,7 @@ const file_proto_chat_proto_rawDesc = "" +
 	"\x0fIsOnlineRequest\x12\x17\n" +
 	"\auser_id\x18\x01 \x01(\tR\x06userId\"*\n" +
 	"\x10IsOnlineResponse\x12\x16\n" +
-	"\x06online\x18\x01 \x01(\bR\x06online*\\\n" +
+	"\x06online\x18\x01 \x01(\bR\x06online*\xc2\x01\n" +
 	"\vMessageType\x12\v\n" +
 	"\aUNKNOWN\x10\x00\x12\b\n" +
 	"\x04JOIN\x10\x01\x12\t\n" +
@@ -278,7 +293,13 @@ const file_proto_chat_proto_rawDesc = "" +
 	"\n" +
 	"\x06TYPING\x10\x04\x12\b\n" +
 	"\x04PING\x10\x05\x12\b\n" +
-	"\x04PONG\x10\x062z\n" +
+	"\x04PONG\x10\x06\x12\x10\n" +
+	"\fTYPING_START\x10\a\x12\x0f\n" +
+	"\vTYPING_STOP\x10\b\x12\x13\n" +
+	"\x0fPRESENCE_ONLINE\x10\t\x12\x14\n" +
+	"\x10PRESENCE_OFFLINE\x10\n" +
+	"\x12\x16\n" +
+	"\x12PRESENCE_SUBSCRIBE\x10\v2z\n" +
 	"\vChatService\x120\n" +
 	"\x04Chat\x12\x11.chat.ChatMessage\x1a\x11.chat.ChatMessage(\x010\x01\x129\n" +
 	"\bIsOnline\x12\x15.chat.IsOnlineRequest\x1a\x16.chat.IsOnlineResponseB+Z)github.com/litG-zen/chat_app/proto;chatpbb\x06proto3"

--- a/proto/chat.proto
+++ b/proto/chat.proto
@@ -17,9 +17,14 @@ enum MessageType {
   JOIN = 1;
   LEAVE = 2;
   MESSAGE = 3;
-  TYPING = 4;
+  TYPING = 4;              // deprecated; superseded by TYPING_START / TYPING_STOP
   PING = 5;
   PONG = 6;
+  TYPING_START = 7;        // sender began composing; To = recipients
+  TYPING_STOP = 8;         // sender stopped composing; To = recipients
+  PRESENCE_ONLINE = 9;     // server -> watcher: user_id came online
+  PRESENCE_OFFLINE = 10;   // server -> watcher: user_id went offline
+  PRESENCE_SUBSCRIBE = 11; // client -> server: To = user_ids to watch
 }
 
 message IsOnlineRequest {

--- a/server/main.go
+++ b/server/main.go
@@ -14,10 +14,17 @@ import (
 	"time"
 
 	"github.com/litG-zen/chat_app/logs"
+	"github.com/litG-zen/chat_app/presence"
 	pb "github.com/litG-zen/chat_app/proto"
 	"github.com/litG-zen/chat_app/utils"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
+
+// presenceOpTimeout bounds individual Redis presence operations so a slow
+// or unhealthy Redis cannot block stream handlers or the heartbeat ticker.
+const presenceOpTimeout = 3 * time.Second
 
 const SERVER_INIT_LOGO = `-----LIT SERVER INITATTED----`
 
@@ -127,6 +134,26 @@ func (h *Hub) SendTo(recipients []string, msg *pb.ChatMessage) {
 	}
 }
 
+// SendTransient delivers msg only to recipients currently connected to this
+// node. Unlike SendTo it must NEVER hit the offline queue: typing and
+// presence events are ephemeral by contract (skills/realtime.md). Offline
+// recipients are silently dropped.
+func (h *Hub) SendTransient(recipients []string, msg *pb.ChatMessage) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	for _, uid := range recipients {
+		c, ok := h.clients[uid]
+		if !ok {
+			continue
+		}
+		select {
+		case c.send <- msg:
+		default:
+			log.Printf("dropping transient %s for %s (send buffer full)", msg.Type, uid)
+		}
+	}
+}
+
 // Broadcast sends msg to all connected clients (non-blocking).
 // It will attempt a non-blocking send to each client's send channel.
 func (h *Hub) Broadcast(senderID string, msg *pb.ChatMessage) {
@@ -146,7 +173,8 @@ func (h *Hub) Broadcast(senderID string, msg *pb.ChatMessage) {
 
 type Server struct {
 	pb.UnimplementedChatServiceServer
-	hub *Hub
+	hub      *Hub
+	presence *presence.Manager
 }
 
 func GetServer() *Server {
@@ -156,6 +184,12 @@ func GetServer() *Server {
 		}
 	})
 	return serverInstance
+}
+
+// SetPresence wires the presence manager into the server. Called from main
+// after the manager has been constructed and Start()-ed.
+func (s *Server) SetPresence(m *presence.Manager) {
+	s.presence = m
 }
 
 func containsStar(recipients []string) bool {
@@ -225,6 +259,36 @@ func (s *Server) Chat(stream pb.ChatService_ChatServer) error {
 				}
 			}
 		}(client)
+
+		// Presence: mark the user online in Redis and refresh the TTL on a
+		// ticker so a crashed node flips the user offline within PresenceTTL.
+		// Failures here are logged, not fatal: the chat stream still works,
+		// the user just isn't visible to remote watchers until Redis recovers.
+		if s.presence != nil {
+			markCtx, markCancel := context.WithTimeout(context.Background(), presenceOpTimeout)
+			if err := s.presence.MarkOnline(markCtx, userID); err != nil {
+				log.Printf("presence: MarkOnline failed for %s: %v", userID, err)
+				logs.Logger(fmt.Sprintf("%v : presence MarkOnline failed for %s: %v", time.Now(), userID, err), true)
+			}
+			markCancel()
+
+			go func(c *Client) {
+				ticker := time.NewTicker(presence.RefreshInterval)
+				defer ticker.Stop()
+				for {
+					select {
+					case <-c.ctx.Done():
+						return
+					case <-ticker.C:
+						refreshCtx, refreshCancel := context.WithTimeout(context.Background(), presenceOpTimeout)
+						if err := s.presence.RefreshTTL(refreshCtx, c.userID); err != nil {
+							log.Printf("presence: RefreshTTL failed for %s: %v", c.userID, err)
+						}
+						refreshCancel()
+					}
+				}
+			}(client)
+		}
 	}
 	log.Printf("user %s joined", userID)
 
@@ -278,12 +342,87 @@ func (s *Server) Chat(stream pb.ChatService_ChatServer) error {
 			log.Printf("%s requested leave", userID)
 			// perform post connection closure actions
 			goto CLEANUP
+		case pb.MessageType_TYPING_START, pb.MessageType_TYPING_STOP:
+			// Transient: never persist, never enqueue offline. Publish to Redis
+			// so the recipient's node can fan out to local clients. If sender
+			// supplied no recipients there is nothing to deliver to.
+			if s.presence == nil || len(msg.To) == 0 || containsStar(msg.To) {
+				continue
+			}
+			state := presence.TypingStart
+			if msg.Type == pb.MessageType_TYPING_STOP {
+				state = presence.TypingStop
+			}
+			pubCtx, pubCancel := context.WithTimeout(context.Background(), presenceOpTimeout)
+			if err := s.presence.PublishTyping(pubCtx, presence.TypingEvent{
+				From:      userID,
+				To:        msg.To,
+				State:     state,
+				Timestamp: msg.Timestamp,
+			}); err != nil {
+				log.Printf("presence: PublishTyping failed for %s: %v", userID, err)
+			}
+			pubCancel()
+		case pb.MessageType_PRESENCE_SUBSCRIBE:
+			// Client requests to watch the users listed in msg.To. Enforce the
+			// per-client cap and surface a structured error inline so the
+			// client can react. Then deliver the current state for each target.
+			if s.presence == nil {
+				continue
+			}
+			for _, target := range msg.To {
+				if target == "" || target == userID {
+					continue
+				}
+				if err := s.presence.AddWatcher(userID, target); err != nil {
+					if presence.IsSubscriptionLimit(err) {
+						log.Printf("presence: subscription limit hit for %s", userID)
+						// Best-effort notification; client may render this as
+						// "too many subscriptions". We don't tear down the stream.
+						s.hub.SendTransient([]string{userID}, &pb.ChatMessage{
+							Type:      pb.MessageType_PRESENCE_OFFLINE,
+							UserId:    target,
+							Timestamp: time.Now().UnixNano() / int64(time.Millisecond),
+							Text:      "subscription_limit",
+						})
+						break
+					}
+					log.Printf("presence: AddWatcher(%s, %s) failed: %v", userID, target, err)
+					continue
+				}
+
+				checkCtx, checkCancel := context.WithTimeout(context.Background(), presenceOpTimeout)
+				online, err := s.presence.IsOnline(checkCtx, target)
+				checkCancel()
+				if err != nil {
+					log.Printf("presence: IsOnline(%s) failed: %v", target, err)
+					continue
+				}
+				evType := pb.MessageType_PRESENCE_OFFLINE
+				if online {
+					evType = pb.MessageType_PRESENCE_ONLINE
+				}
+				s.hub.SendTransient([]string{userID}, &pb.ChatMessage{
+					Type:      evType,
+					UserId:    target,
+					Timestamp: time.Now().UnixNano() / int64(time.Millisecond),
+				})
+			}
 		default:
-			// handle PING/TYPING etc
+			// handle PING etc
 		}
 	}
 
 CLEANUP:
+	if s.presence != nil {
+		offCtx, offCancel := context.WithTimeout(context.Background(), presenceOpTimeout)
+		if err := s.presence.MarkOffline(offCtx, userID); err != nil {
+			log.Printf("presence: MarkOffline failed for %s: %v", userID, err)
+			logs.Logger(fmt.Sprintf("%v : presence MarkOffline failed for %s: %v", time.Now(), userID, err), true)
+		}
+		offCancel()
+		s.presence.RemoveAllWatchers(userID)
+	}
 	s.hub.Unregister(userID)
 	log_string := fmt.Sprintf("%v : %v has been unregistered", time.Now(), userID)
 	logs.Logger(log_string, true)
@@ -291,10 +430,36 @@ CLEANUP:
 	return nil
 }
 
-// Unary RPC to check if a user is online
+// Unary RPC to check if a user is online. Delegates to the Redis-backed
+// presence store so the answer is correct across nodes; falls back to the
+// local hub if presence is unavailable.
 func (s *Server) IsOnline(ctx context.Context, req *pb.IsOnlineRequest) (*pb.IsOnlineResponse, error) {
-	online := s.hub.IsOnline(req.UserId)
-	return &pb.IsOnlineResponse{Online: online}, nil
+	if req.UserId == "" {
+		return nil, status.Error(codes.InvalidArgument, "user_id required")
+	}
+	if s.presence != nil {
+		online, err := s.presence.IsOnline(ctx, req.UserId)
+		if err != nil {
+			log.Printf("presence: IsOnline RPC failed for %s: %v", req.UserId, err)
+			return nil, status.Errorf(codes.Unavailable, "presence lookup failed: %v", err)
+		}
+		return &pb.IsOnlineResponse{Online: online}, nil
+	}
+	return &pb.IsOnlineResponse{Online: s.hub.IsOnline(req.UserId)}, nil
+}
+
+// resolveNodeID returns a stable identifier for this server process. Used to
+// tag presence events so we can debug which node a user was on. Prefers an
+// explicit NODE_ID env var; falls back to hostname:pid.
+func resolveNodeID() string {
+	if v := os.Getenv("NODE_ID"); v != "" {
+		return v
+	}
+	host, err := os.Hostname()
+	if err != nil {
+		host = "unknown"
+	}
+	return fmt.Sprintf("%s:%d", host, os.Getpid())
 }
 
 func main() {
@@ -304,6 +469,51 @@ func main() {
 	}
 	grpcServer := grpc.NewServer() // add interceptors / TLS creds in production
 	srv := GetServer()
+
+	// Presence subsystem. Constructed before any client can connect so that
+	// JOIN/MarkOnline never races against a half-initialised manager.
+	presenceCtx, presenceCancel := context.WithCancel(context.Background())
+	defer presenceCancel()
+
+	rdb, err := utils.GetRedisInstance()
+	if err != nil {
+		log.Fatalf("presence: redis init failed: %v", err)
+	}
+	rawClient := rdb.Client()
+	if rawClient == nil {
+		log.Fatalf("presence: redis client not initialised")
+	}
+	nodeID := resolveNodeID()
+	mgr := presence.NewManager(rawClient, nodeID)
+	mgr.OnPresenceEvent(func(ev presence.PresenceEvent, watchers []string) {
+		evType := pb.MessageType_PRESENCE_OFFLINE
+		if ev.State == presence.StateOnline {
+			evType = pb.MessageType_PRESENCE_ONLINE
+		}
+		srv.hub.SendTransient(watchers, &pb.ChatMessage{
+			Type:      evType,
+			UserId:    ev.UserID,
+			Timestamp: ev.Timestamp,
+		})
+	})
+	mgr.OnTypingEvent(func(ev presence.TypingEvent) {
+		evType := pb.MessageType_TYPING_STOP
+		if ev.State == presence.TypingStart {
+			evType = pb.MessageType_TYPING_START
+		}
+		srv.hub.SendTransient(ev.To, &pb.ChatMessage{
+			Type:      evType,
+			UserId:    ev.From,
+			To:        ev.To,
+			Timestamp: ev.Timestamp,
+		})
+	})
+	if err := mgr.Start(presenceCtx); err != nil {
+		log.Fatalf("presence: manager start failed: %v", err)
+	}
+	srv.SetPresence(mgr)
+	log.Printf("presence: subsystem started, node_id=%s", nodeID)
+
 	pb.RegisterChatServiceServer(grpcServer, srv)
 	log.Println(SERVER_INIT_LOGO)
 	logs.Logger(fmt.Sprintf("%v : Server Bootup!", time.Now()), false)
@@ -327,6 +537,9 @@ func main() {
 
 		// Force-cancel client streams so handlers return, then let GracefulStop
 		// flush in-flight RPCs. Fall back to Stop() if it drags on.
+		// Cancel presence subscribers first so they don't keep publishing to
+		// closing streams.
+		presenceCancel()
 		srv.hub.CloseAll()
 
 		done := make(chan struct{})

--- a/server/main.go
+++ b/server/main.go
@@ -26,7 +26,7 @@ import (
 // or unhealthy Redis cannot block stream handlers or the heartbeat ticker.
 const presenceOpTimeout = 3 * time.Second
 
-const SERVER_INIT_LOGO = `-----LIT SERVER INITATTED----`
+const SERVER_INIT_LOGO = `-----LIT SERVER INITIATED----`
 
 // New client structure, with request-context and connection-steam variables.
 type Client struct {

--- a/utils/redisConnector.go
+++ b/utils/redisConnector.go
@@ -82,6 +82,15 @@ func GetRedisInstance() (*RedisClient, error) {
 	return redisClient, nil
 }
 
+// Client exposes the underlying go-redis client for callers that need pub/sub
+// or other primitives not surfaced by this wrapper. Returns nil if the
+// connection has not yet been initialised.
+func (r *RedisClient) Client() *redis.Client {
+	r.mutex.RLock()
+	defer r.mutex.RUnlock()
+	return r.client
+}
+
 // AddMessageForUser adds a serialized message to the recipient's Redis list.
 func AddMessageForUser(msg RedisMessage) error {
 	rdb, err := GetRedisInstance()


### PR DESCRIPTION
## Summary

Adds a presence subsystem so users can see when counterparts come online/offline and when they're composing, designed for horizontal scale via Redis pub/sub.

- **New `presence/` package**: `Manager` lifecycle + callbacks, Redis-backed store (`presence:<userID>` keys with 30s TTL refreshed every 10s by a per-client heartbeat), and a bidirectional watcher index with a hard 1000-subscription cap per client.
- **Wire protocol (additive, non-breaking)**: 5 new `MessageType` values — `TYPING_START`, `TYPING_STOP`, `PRESENCE_ONLINE`, `PRESENCE_OFFLINE`, `PRESENCE_SUBSCRIBE`. Legacy `TYPING` kept for compatibility.
- **`Hub.SendTransient`**: a new fanout path for ephemeral events that never touches the offline queue — enforces the `skills/realtime.md` "never persist transient events" rule at the type level.
- **Cross-node correctness**: `IsOnline` RPC now consults Redis (was local-only), returning `InvalidArgument` / `Unavailable` codes as appropriate. Local hub remains the fallback if presence is disabled.
- **Two pub/sub channels** — `presence:events` and `typing:events` — separated to avoid head-of-line blocking between high-frequency typing traffic and low-frequency presence transitions.
- **Crash recovery**: presence keys expire within 30s of a server crash, flipping abandoned users offline without intervention.
- **Client**: emits `PRESENCE_SUBSCRIBE` for the target on connect, renders incoming presence/typing events distinctly, and frames each prompt with `TYPING_START` / `TYPING_STOP` (line-buffered CLI heuristic; server-side TTL covers the "user walked away" case).

### Architecture decisions worth flagging

- **Always-through-Redis fanout** (no local fast-path) — slight latency cost (~1ms) for invariant simplicity; same-node and cross-node take the same code path.
- **Subscription cap of 1000 per client** — prevents memory blow-up from a buggy/malicious client; cap-breach returns `PRESENCE_OFFLINE` with `subscription_limit` marker rather than tearing down the stream.
- **Hard Redis dependency at startup** — `main()` now eagerly initializes Redis (presence requires pub/sub). Behavior change: server previously booted without Redis and failed lazily on first offline write; it now fails fast at startup if `REDIS_URL` isn't reachable.

### Known limitations (deferred)

1. CLI typing UX is a line-buffer heuristic — proper raw-mode terminal handling is a separate ticket.
2. Per-client heartbeat goroutine scales linearly; batched TTL refresh needed past ~10K connections.
3. No `last_seen` timestamp — only "online now" is tracked.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./presence/ -count=1` — 5 tests pass (watcher map idempotency, subscription cap, bidirectional cleanup, concurrent add/remove, re-add at cap)
- [x] **Manual smoke (3 terminals, `REDIS_URL` set):**
  - [x] lalit connects first → sees `lit is offline` immediately
  - [x] lit connects → lalit sees `lit is online`
  - [x] lit sits at prompt → lalit sees `lit is typing...`
   [ ] **Crash recovery**: kill the server abruptly; within 30s `presence:<userID>` expires and `IsOnline` returns false.
- [ ] **Cross-node (optional)**: second server on a different port, client on each. Presence and typing flow correctly between them.

<img width="2879" height="1632" alt="Screenshot 2026-05-24 003904" src="https://github.com/user-attachments/assets/3edbbf54-46c4-4e3e-8b17-b739479d3b8c" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)